### PR TITLE
chore: correct entrypoint script to not exit on failed robot-tests

### DIFF
--- a/library/integration_library_builtIn/PlatformLibrary.py
+++ b/library/integration_library_builtIn/PlatformLibrary.py
@@ -1667,7 +1667,7 @@ class PlatformLibrary(object):
         """
         Returns logs from a given pod in the specified namespace and container.
         """
-        
+
         return self.k8s_core_v1_client.read_namespaced_pod_log(
             name=pod_name,
             namespace=namespace,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [*] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Resolves the issue from PR #102 when robot-tests FAIL result lead to container restart instead of running ttyd.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
