### PR TITLE
fix: prevent crash when labels or selector are None or not dict

### DIFF
--- a/library/integration_library_builtIn/PlatformLibrary.py
+++ b/library/integration_library_builtIn/PlatformLibrary.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ssl
 import time
 from typing import List
 
 import kubernetes
 import urllib3
-import ssl
 import yaml
 from deprecated import deprecated
 from kubernetes import client, config


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [* ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fix prevents crash when in a namespace there's a pod without labels (some debug pod) causing None result in robot tests for getting pod names by selector even if target pods exist.



## Related Tickets & Documents

- Closes #112 

## QA Instructions, Screenshots, Recordings

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
