### PR TITLE
fix: No module named 'PlatformLibrary'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.14-alpine3.23
 
 ENV ROBOT_HOME=/opt/robot \
-    PYTHONPATH=/usr/local/lib/python3.13/site-packages/integration_library_builtIn \
+    PYTHONPATH=/usr/local/lib/python3.14/site-packages/integration_library_builtIn \
     IS_ANALYZER_RESULT_ENABLED=true \
     IS_TAGS_RESOLVER_ENABLED=true \
     STATUS_WRITING_ENABLED=false \


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After upgrade to 3.14 python (https://github.com/Netcracker/qubership-docker-integration-tests/pull/94) tests fail with the following error:

```
Traceback (most recent call last):
  File "/opt/robot/write_status.py", line 21, in <module>
    from PlatformLibrary import PlatformLibrary
ModuleNotFoundError: No module named 'PlatformLibrary'
Can not set in progress status for integration tests
Traceback (most recent call last):
  File "/opt/robot/opensearch_pods_checker.py", line 23, in <module>
    from PlatformLibrary import PlatformLibrary
ModuleNotFoundError: No module named 'PlatformLibrary'
```

As a solution, changed `python3.13` to `python3.14` in PYTHONPATH environment variable.

What's done:
1. Update `PYTHONPATH` environment variable with new python version.