### PR TITLE
fix: atp integration tests tags

### DIFF
--- a/scripts/adapter-S3/adapter-S3-entrypoint.sh
+++ b/scripts/adapter-S3/adapter-S3-entrypoint.sh
@@ -31,21 +31,21 @@ echo " Robot arguments: $*"
 # Initialize environment
 init_environment
 
-# Start upload monitoring only if ATP report upload is enabled and bucket is set
-if atp_report_upload_enabled && [[ -n "${ATP_STORAGE_BUCKET}" ]]; then
+# Start upload monitoring only when publishing to S3 (bucket set)
+if atp_report_upload; then
     start_upload_monitoring
 else
-    echo " Skipping upload monitoring (ATP report upload disabled or bucket not set)"
+    echo " Skipping upload monitoring (no bucket — results stay local)"
 fi
 
 # Run tests
 run_tests "$@"
 
-# Finalize upload only if ATP report upload is enabled and bucket is set
-if atp_report_upload_enabled && [[ -n "${ATP_STORAGE_BUCKET}" ]]; then
+# Finalize upload only when publishing to S3 (bucket set)
+if atp_report_upload; then
     finalize_upload
 else
-    echo " Skipping upload finalization (ATP report upload disabled or bucket not set)"
+    echo " Skipping upload finalization (no bucket — results stay local)"
     echo " Test results are available locally at: $TMP_DIR"
 fi
 

--- a/scripts/adapter-S3/init.sh
+++ b/scripts/adapter-S3/init.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# atpReport.enabled (Helm) -> ATP_REPORT_ENABLED: only "true" or "false"
-: "${ATP_REPORT_ENABLED:=false}"
+# Adapter-S3 is only sourced when the ATP report path is active (see docker-entrypoint.sh).
 
-atp_report_upload_enabled() {
-    [[ "${ATP_REPORT_ENABLED}" == "true" ]]
+# True when a bucket is set — actually publish reports to S3. Empty bucket: run tests, no S3 publish.
+atp_report_upload() {
+    [[ -n "${ATP_STORAGE_BUCKET:-}" ]]
 }
 
 # Environment initialization module
@@ -19,41 +19,48 @@ init_environment() {
         CURRENT_TIME=$(date +%H-%M-%S) # e.g., 11-48-00
     fi
 
-    # ATP report upload to S3: requires ATP_REPORT_ENABLED=true and ATP_STORAGE_BUCKET
-    if atp_report_upload_enabled; then
-        if [[ -z "${ATP_STORAGE_BUCKET}" ]]; then
-            echo "ERROR: ATP_REPORT_ENABLED is true but ATP_STORAGE_BUCKET is not set"
-            exit 1
-        fi
-        echo "ATP report upload to S3 enabled (bucket: ${ATP_STORAGE_BUCKET})"
+    # Bucket set: full S3 publish path — fail fast if creds/settings are incomplete (exit 1 → pod Error, not stuck Running+ttyd).
+    if atp_report_upload; then
+        local _missing=()
+        [[ -z "${ATP_STORAGE_PROVIDER:-}" ]] && _missing+=(ATP_STORAGE_PROVIDER)
+        [[ -z "${ATP_STORAGE_USERNAME:-}" ]] && _missing+=(ATP_STORAGE_USERNAME)
+        [[ -z "${ATP_STORAGE_PASSWORD:-}" ]] && _missing+=(ATP_STORAGE_PASSWORD)
+        [[ -z "${ENVIRONMENT_NAME:-}" ]] && _missing+=(ENVIRONMENT_NAME)
 
-        # Configure AWS S3 parameters (required when upload is enabled) - using local variables for security
-        if [[ -z "${ATP_STORAGE_USERNAME}" ]]; then
-            echo "ERROR: ATP_STORAGE_USERNAME is required but not set"
+        local _prov_lc="${ATP_STORAGE_PROVIDER,,}"
+        case "${_prov_lc}" in
+        aws)
+            [[ -z "${ATP_STORAGE_REGION:-}" ]] && _missing+=(ATP_STORAGE_REGION)
+            ;;
+        minio | s3)
+            [[ -z "${ATP_STORAGE_SERVER_URL:-}" ]] && _missing+=(ATP_STORAGE_SERVER_URL)
+            [[ -z "${ATP_STORAGE_REGION:-}" ]] && _missing+=(ATP_STORAGE_REGION)
+            ;;
+        *)
+            echo "ERROR: ATP_STORAGE_PROVIDER must be aws, minio, or s3 (got: '${ATP_STORAGE_PROVIDER:-}')"
             exit 1
-        fi
-        if [[ -z "${ATP_STORAGE_PASSWORD}" ]]; then
-            echo "ERROR: ATP_STORAGE_PASSWORD is required but not set"
+            ;;
+        esac
+
+        if [[ ${#_missing[@]} -gt 0 ]]; then
+            echo "ERROR: S3 upload is configured (ATP_STORAGE_BUCKET is set) but required variables are missing or empty: ${_missing[*]}"
             exit 1
         fi
 
-        # Store credentials in local variables (not exported to environment)
+        echo "ATP report upload to S3 enabled (provider: ${ATP_STORAGE_PROVIDER}, bucket: ${ATP_STORAGE_BUCKET})"
+
         _LOCAL_S3_KEY="$ATP_STORAGE_USERNAME"
         _LOCAL_S3_SECRET="$ATP_STORAGE_PASSWORD"
         export AWS_ACCESS_KEY_ID="$_LOCAL_S3_KEY"
         export AWS_SECRET_ACCESS_KEY="$_LOCAL_S3_SECRET"
+        export AWS_REGION="${ATP_STORAGE_REGION}"
 
-        # Configure additional s5cmd settings for MinIO only
-        if [[ "${ATP_STORAGE_PROVIDER}" == "minio" || "${ATP_STORAGE_PROVIDER}" == "s3" ]]; then
+        if [[ "${_prov_lc}" == "minio" || "${_prov_lc}" == "s3" ]]; then
             export AWS_ENDPOINT_URL="${ATP_STORAGE_SERVER_URL}"
-            export AWS_REGION="${ATP_STORAGE_REGION}" # Required by s5cmd even for MinIO
-            export AWS_NO_VERIFY_SSL="true"           # Optional: disable SSL verification
+            export AWS_NO_VERIFY_SSL="true"
         fi
     else
-        echo "WARNING: ATP report upload to S3 disabled (set ATP_REPORT_ENABLED=true to enable)"
-        if [[ -n "${ATP_STORAGE_BUCKET}" ]]; then
-            echo "INFO: ATP_STORAGE_BUCKET is set (${ATP_STORAGE_BUCKET}) but uploads remain disabled until ATP_REPORT_ENABLED=true"
-        fi
+        echo "INFO: ATP_STORAGE_BUCKET is empty — running tests without S3 upload."
     fi
 
     # Define temp clone path

--- a/scripts/adapter-S3/test-runner.sh
+++ b/scripts/adapter-S3/test-runner.sh
@@ -19,8 +19,8 @@ run_tests() {
         exit 1
     fi
 
-    # Clear sensitive variables before tests (only if S3 is enabled)
-    if [[ -n "${ATP_STORAGE_BUCKET}" ]]; then
+    # Clear credentials from the environment only when S3 publish was configured (bucket + ATP on).
+    if atp_report_upload; then
         echo "Clearing sensitive environment variables before tests..."
         clear_sensitive_vars
     fi

--- a/scripts/adapter-S3/upload-monitor.sh
+++ b/scripts/adapter-S3/upload-monitor.sh
@@ -3,8 +3,8 @@
 # Event-based upload monitoring module
 start_upload_monitoring() {
     # Skip if ATP report upload is disabled or bucket is missing
-    if ! atp_report_upload_enabled || [[ -z "${ATP_STORAGE_BUCKET}" ]]; then
-        echo "WARNING: Skipping upload monitoring (ATP report upload disabled or ATP_STORAGE_BUCKET not set)"
+    if ! atp_report_upload; then
+        echo "WARNING: Skipping upload monitoring (no bucket — no S3 publish)"
         return 0
     fi
 
@@ -114,8 +114,8 @@ sync_directory_to_s3() {
 # Finalize upload after tests
 finalize_upload() {
     # Skip if ATP report upload is disabled or bucket is missing
-    if ! atp_report_upload_enabled || [[ -z "${ATP_STORAGE_BUCKET}" ]]; then
-        echo "WARNING: Skipping upload finalization (ATP report upload disabled or ATP_STORAGE_BUCKET not set)"
+    if ! atp_report_upload; then
+        echo "WARNING: Skipping upload finalization (no bucket — no S3 publish)"
         echo "Test results are available locally at: $TMP_DIR"
         return 0
     fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -81,8 +81,12 @@ run_robot() {
         robot_args+=("-i" "$TAGS")
     fi
     if [[ -n "$excluded_tags" ]]; then
-        # Shell-split the "-e ..." prefix into args like the standard branch effectively does.
-        robot_args+=($excluded_tags)
+        # robot_tags_resolver.py emits "-e tag1ORtag2..."; pass as two argv tokens (no unquoted expansion).
+        if [[ "$excluded_tags" =~ ^-e[[:space:]]+(.*)$ ]]; then
+            robot_args+=("-e" "${BASH_REMATCH[1]}")
+        else
+            robot_args+=("$excluded_tags")
+        fi
     fi
     robot_args+=("./tests")
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -73,41 +73,16 @@ run_robot() {
         excluded_tags=${tags_resolver_array[0]}
     fi
 
+    # Build args exactly like the standard (non-ATP) branch does:
+    # - pass TAGS as a single -i expression (so NOT/OR/AND semantics are identical)
+    # - pass excluded_tags as-is (it's produced like: "-e tag1ORtag2")
     robot_args=()
     if [[ -n "$TAGS" ]]; then
-        # Split by OR and add each tag as separate -i parameter
-        IFS='OR' read -ra tag_array <<<"$TAGS"
-        for tag in "${tag_array[@]}"; do
-            # Skip empty tags
-            if [[ -n "$tag" ]]; then
-                robot_args+=("-i" "$tag")
-            fi
-        done
+        robot_args+=("-i" "$TAGS")
     fi
     if [[ -n "$excluded_tags" ]]; then
-        # Remove the -e flag if it's already present and parse the tags
-        if [[ "$excluded_tags" =~ ^-e[[:space:]]+(.*)$ ]]; then
-            # Extract tags without -e flag
-            tags_only="${BASH_REMATCH[1]}"
-            # Split by OR and add each tag as separate -e parameter
-            IFS='OR' read -ra excluded_tag_array <<<"$tags_only"
-            for tag in "${excluded_tag_array[@]}"; do
-                # Skip empty tags
-                if [[ -n "$tag" ]]; then
-                    robot_args+=("-e" "$tag")
-                fi
-            done
-        else
-            # No -e flag present, add it
-            # Split by OR and add each tag as separate -e parameter
-            IFS='OR' read -ra excluded_tag_array <<<"$excluded_tags"
-            for tag in "${excluded_tag_array[@]}"; do
-                # Skip empty tags
-                if [[ -n "$tag" ]]; then
-                    robot_args+=("-e" "$tag")
-                fi
-            done
-        fi
+        # Shell-split the "-e ..." prefix into args like the standard branch effectively does.
+        robot_args+=($excluded_tags)
     fi
     robot_args+=("./tests")
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When ATP report upload is enabled (`ATP_REPORT_ENABLED=true`), integration tests are started via `adapter-S3-entrypoint.sh` with arguments built in `scripts/docker-entrypoint.sh`. The previous logic tried to split `TAGS` and excluded-tag strings on `OR` using `IFS='OR'`. In Bash, `IFS` is a set of **single-character** delimiters, so the string was split on every `O` and `R`, not on the `OR` token. That broke valid Robot tag patterns such as `zookeeperNOTtransactional_backup` (they became unrelated fragments like `zookeeperN` and `Ttransactional_backup`), so Robot reported no matching tests while the non-ATP path still worked.

This change builds `robot_args` the same way as the standard branch: a single `-i "$TAGS"` when tags are set, and excluded tags passed in the same shape as produced by `robot_tags_resolver.py` (`-e tag1ORtag2...`), so Robot sees the same include/exclude patterns with or without ATP.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue [#132](https://github.com/Netcracker/qubership-zookeeper/issues/132) 
- Closes #

## QA Instructions, Screenshots, Recordings

1. Build or use an image that includes this `docker-entrypoint.sh`.
2. Run integration tests **with** `ATP_REPORT_ENABLED=true` and a `TAGS` value that contains `NOT` inside the pattern (for example `zookeeperNOTtransactional_backup`, as used in ZooKeeper pipelines).
3. Confirm logs show a single `-i` argument with the full original tag string (not split into bogus fragments) and that Robot finds and runs tests as with ATP disabled.
4. Optionally repeat with `TAGS` containing explicit `OR` / `AND` patterns and verify behavior matches a run with `ATP_REPORT_ENABLED=false`.

### Breaking Change checklist

_If your PR includes any deployment or processing changes, please utilize this checklist:_

- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: The fix is in shell argument construction for Robot; validating it is done by running the integration test image with ATP on/off and comparing Robot CLI arguments and exit behavior. No automated unit test harness exists for this script in-repo.
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check?

Excluded tags are still appended with `robot_args+=($excluded_tags)` (unquoted) so the leading `-e` and the combined `OR` pattern remain two argv tokens for Robot, consistent with how the resolver formats the string.

## [optional] What gif best describes this PR or how it makes you feel?