### PR TITLE
feat: implement dynamic image resolution for container hardening jobs

### DIFF
--- a/container-hardening/helm/container-hardening/templates/_helpers.tpl
+++ b/container-hardening/helm/container-hardening/templates/_helpers.tpl
@@ -78,3 +78,25 @@ Selector labels.
 app.kubernetes.io/name: {{ include "container-hardening.name" . }}
 app.kubernetes.io/instance: {{ cat (include "container-hardening.name" .) .Values.DELIMITER .Release.Namespace | nospace | trunc 63 }}
 {{- end -}}
+
+{{/*
+Resolve the container-hardening runner image.
+When the App Deployer injects .Values.deployDescriptor the image is read from
+the descriptor; otherwise falls back to .Values.containerHardening.image so
+the chart keeps working standalone.
+*/}}
+{{- define "find_image" -}}
+  {{- $image := .default -}}
+  {{- if .vals.deployDescriptor -}}
+    {{- if index .vals.deployDescriptor .deployName -}}
+      {{- $image = (index .vals.deployDescriptor .deployName "image") -}}
+    {{- else if index .vals.deployDescriptor .SERVICE_NAME -}}
+      {{- $image = (index .vals.deployDescriptor .SERVICE_NAME "image") -}}
+    {{- end -}}
+  {{- end -}}
+  {{- printf "%s" $image -}}
+{{- end -}}
+
+{{- define "container-hardening.findImage" -}}
+  {{- include "find_image" (dict "deployName" "containerHardening" "SERVICE_NAME" "container-hardening-image" "vals" .Values "default" .Values.containerHardening.image) -}}
+{{- end -}}

--- a/container-hardening/helm/container-hardening/templates/job.yaml
+++ b/container-hardening/helm/container-hardening/templates/job.yaml
@@ -38,7 +38,7 @@ spec:
         {{- include "container-hardening.globalPodSecurityContext" . | nindent 8 }}
       containers:
         - name: {{ include "container-hardening.name" . }}
-          image: {{ .Values.containerHardening.image }}
+          image: {{ include "container-hardening.findImage" . | trim }}
           imagePullPolicy: Always
           args: ["run-robot-without-ttyd"]
           env:


### PR DESCRIPTION
- Added a new helper function to resolve the container-hardening runner image based on the presence of a deployment descriptor. This allows for fallback to a default image when the descriptor is not provided.
- Updated the job template to utilize the new image resolution function, ensuring that the correct image is used for the container hardening job.

These changes enhance the flexibility and usability of the Helm chart by allowing for dynamic image selection.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TDB

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
