### PR TITLE
fix: Refactor get_kubernetes_api_client for Python 3.13

### DIFF
--- a/library/integration_library_builtIn/PlatformLibrary.py
+++ b/library/integration_library_builtIn/PlatformLibrary.py
@@ -17,6 +17,7 @@ import ssl
 import sys
 import time
 from typing import Dict, List, Optional, Union
+
 import kubernetes
 import urllib3
 import yaml

--- a/library/integration_library_builtIn/PlatformLibrary.py
+++ b/library/integration_library_builtIn/PlatformLibrary.py
@@ -26,6 +26,7 @@ from kubernetes.stream import stream
 from robot.api import logger as robot_logger
 from KubernetesClient import KubernetesClient
 from OpenShiftClient import OpenShiftClient  # noqa: F401
+from kubernetes.client.configuration import Configuration
 
 # Forbidden container ports per CH8 rule (security hardening).
 _FORBIDDEN_PORTS = frozenset(

--- a/library/integration_library_builtIn/PlatformLibrary.py
+++ b/library/integration_library_builtIn/PlatformLibrary.py
@@ -16,7 +16,7 @@ import os
 import ssl
 import time
 from typing import Dict, List, Optional, Union
-
+import sys
 import kubernetes
 import urllib3
 import yaml
@@ -40,8 +40,17 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 def get_kubernetes_api_client(config_file=None, context=None, persist_config=True):
     try:
-        config.load_incluster_config()
-        return patchK8sClient(kubernetes.client.ApiClient())
+        client_configuration = None
+        if sys.version_info >= (3, 13):
+            # https://docs.python.org/3/whatsnew/3.13.html#ssl
+            # Kubernetes client issue
+            # https://github.com/kubernetes-client/python/issues/2394#issuecomment-2884974440
+            client_configuration = Configuration()
+            client_configuration.verify_ssl = False
+
+        config.load_incluster_config(client_configuration)
+
+        return kubernetes.client.ApiClient(configuration=client_configuration)
     except config.ConfigException:
         return patchK8sClient(kubernetes.config.new_client_from_config(
             config_file=config_file,

--- a/library/integration_library_builtIn/PlatformLibrary.py
+++ b/library/integration_library_builtIn/PlatformLibrary.py
@@ -14,19 +14,19 @@
 
 import os
 import ssl
+import sys
 import time
 from typing import Dict, List, Optional, Union
-import sys
 import kubernetes
 import urllib3
 import yaml
 from deprecated import deprecated
 from kubernetes import client, config
+from kubernetes.client.configuration import Configuration
 from kubernetes.stream import stream
-from robot.api import logger as robot_logger
 from KubernetesClient import KubernetesClient
 from OpenShiftClient import OpenShiftClient  # noqa: F401
-from kubernetes.client.configuration import Configuration
+from robot.api import logger as robot_logger
 
 # Forbidden container ports per CH8 rule (security hardening).
 _FORBIDDEN_PORTS = frozenset(


### PR DESCRIPTION
Update Kubernetes client configuration handling to support Python 3.13 and later.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TDB

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
