### PR TITLE
feat: reroute sync logs to null

### DIFF
--- a/scripts/adapter-S3/upload-monitor.sh
+++ b/scripts/adapter-S3/upload-monitor.sh
@@ -133,28 +133,28 @@ finalize_upload() {
     # Final sync to ensure all files are captured
     if [[ "$ATP_STORAGE_PROVIDER" == "aws" ]]; then
         : "${ALLURE_RESULTS_DIR:=${ROBOT_HOME}/output/allure-results}"
-        s5cmd --no-verify-ssl sync "$ALLURE_RESULTS_DIR/" "${RESULTS_S3_PATH}allure-results/"
+        s5cmd --no-verify-ssl sync "$ALLURE_RESULTS_DIR/" "${RESULTS_S3_PATH}allure-results/" >/dev/null 2>&1
         s5cmd --no-verify-ssl sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH" 2>/dev/null || true
         # Sync email-notification-generated only if it exists
         if [[ -d "$TMP_DIR/scripts/email-notification-generated" ]]; then
-            s5cmd --no-verify-ssl sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/"
+            s5cmd --no-verify-ssl sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/" >/dev/null 2>&1
         fi
     elif [[ "$ATP_STORAGE_PROVIDER" == "minio" || "$ATP_STORAGE_PROVIDER" == "s3" ]]; then
         : "${ALLURE_RESULTS_DIR:=${ROBOT_HOME}/output/allure-results}"
-        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$ALLURE_RESULTS_DIR/" "${RESULTS_S3_PATH}allure-results/"
+        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$ALLURE_RESULTS_DIR/" "${RESULTS_S3_PATH}allure-results/" >/dev/null 2>&1
         s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH" 2>/dev/null || true
         # Sync email-notification-generated only if it exists
         if [[ -d "$TMP_DIR/scripts/email-notification-generated" ]]; then
-            s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/"
+            s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/" >/dev/null 2>&1
         fi
     fi
 
     # Upload marker file
     echo "${ENABLE_JIRA_INTEGRATION:-false}" >"$TMP_DIR/allure-results.uploaded"
     if [[ "$ATP_STORAGE_PROVIDER" == "aws" ]]; then
-        s5cmd --no-verify-ssl cp "$TMP_DIR/allure-results.uploaded" "${RESULTS_S3_PATH}allure-results.uploaded"
+        s5cmd --no-verify-ssl cp "$TMP_DIR/allure-results.uploaded" "${RESULTS_S3_PATH}allure-results.uploaded" >/dev/null 2>&1
     elif [[ "$ATP_STORAGE_PROVIDER" == "minio" || "$ATP_STORAGE_PROVIDER" == "s3" ]]; then
-        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" cp "$TMP_DIR/allure-results.uploaded" "${RESULTS_S3_PATH}allure-results.uploaded"
+        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" cp "$TMP_DIR/allure-results.uploaded" "${RESULTS_S3_PATH}allure-results.uploaded" >/dev/null 2>&1
     fi
 
     # Generate result URLs

--- a/scripts/adapter-S3/upload-monitor.sh
+++ b/scripts/adapter-S3/upload-monitor.sh
@@ -134,7 +134,7 @@ finalize_upload() {
     if [[ "$ATP_STORAGE_PROVIDER" == "aws" ]]; then
         : "${ALLURE_RESULTS_DIR:=${ROBOT_HOME}/output/allure-results}"
         s5cmd --no-verify-ssl sync "$ALLURE_RESULTS_DIR/" "${RESULTS_S3_PATH}allure-results/" >/dev/null 2>&1
-        s5cmd --no-verify-ssl sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH" 2>/dev/null || true
+        s5cmd --no-verify-ssl sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH" >/dev/null || true
         # Sync email-notification-generated only if it exists
         if [[ -d "$TMP_DIR/scripts/email-notification-generated" ]]; then
             s5cmd --no-verify-ssl sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/" >/dev/null 2>&1
@@ -142,7 +142,7 @@ finalize_upload() {
     elif [[ "$ATP_STORAGE_PROVIDER" == "minio" || "$ATP_STORAGE_PROVIDER" == "s3" ]]; then
         : "${ALLURE_RESULTS_DIR:=${ROBOT_HOME}/output/allure-results}"
         s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$ALLURE_RESULTS_DIR/" "${RESULTS_S3_PATH}allure-results/" >/dev/null 2>&1
-        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH" 2>/dev/null || true
+        s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/attachments/" "$ATTACHMENTS_S3_PATH" >/dev/null || true
         # Sync email-notification-generated only if it exists
         if [[ -d "$TMP_DIR/scripts/email-notification-generated" ]]; then
             s5cmd --no-verify-ssl --endpoint-url "$ATP_STORAGE_SERVER_URL" sync "$TMP_DIR/scripts/email-notification-generated/" "${RESULTS_S3_PATH}email-notification-generated/" >/dev/null 2>&1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently any tests produce a lot of log output on cp command from s5cmd
The current PR suppresses all the logs.


## QA Instructions, Screenshots, Recordings

Run any test verify that cp logs are suppresed


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: not applicable
- [ ] I need help with writing tests


