### PR TITLE
fix: atp integration secrets should be propagated via path mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,14 +290,19 @@ These variables enable automatic upload of test results and reports to S3-compat
 * `ATP_STORAGE_SERVER_UI_URL` - S3 UI URL for browsing uploaded files (optional, e.g., <https://minio-ui.example.com>)
 * `ATP_STORAGE_BUCKET` - S3 bucket name for storing test results (required when `ATP_REPORT_ENABLED` is true)
 * `ATP_STORAGE_REGION` - S3 region (optional, default: us-east-1). Required for AWS S3
+* `INTEGRATION_TESTS_SECRETS_DIR` - Directory where Kubernetes mounts integration test credentials as files. Set this to the secret volume `mountPath` when using file-based secrets. When unset, credentials are read from environment variables only (legacy `secretKeyRef` / docker-compose)
 * `ATP_STORAGE_USERNAME` - S3 credentials username:
   * For AWS S3: AWS Access Key ID
   * For MinIO: MinIO Access Key
   * Required when `ATP_REPORT_ENABLED` is true
+  * **Kubernetes (recommended):** file `{INTEGRATION_TESTS_SECRETS_DIR}/ATP_STORAGE_USERNAME`
+  * **Backward compatibility:** environment variable when the file is not present (docker-compose, legacy Helm charts with `secretKeyRef`)
 * `ATP_STORAGE_PASSWORD` - S3 credentials password:
   * For AWS S3: AWS Secret Access Key
   * For MinIO: MinIO Secret Key
   * Required when `ATP_REPORT_ENABLED` is true
+  * **Kubernetes (recommended):** file `{INTEGRATION_TESTS_SECRETS_DIR}/ATP_STORAGE_PASSWORD`
+  * **Backward compatibility:** environment variable when the file is not present (docker-compose, legacy Helm charts with `secretKeyRef`)
 * `ATP_REPORT_VIEW_UI_URL` - URL for viewing Allure reports (optional, e.g., <https://allure.example.com>)
 * `ENVIRONMENT_NAME` - Environment name for organizing test results in S3 (e.g., dev, staging, prod). Results are stored in: `s3://{bucket}/Result/{environment}/{date}/{time}/`
 * `UPLOAD_METHOD` - Upload method: `sync` (directory sync) or `cp` (file-by-file upload, default: sync)

--- a/scripts/adapter-S3/init.sh
+++ b/scripts/adapter-S3/init.sh
@@ -7,9 +7,37 @@ atp_report_upload() {
     [[ -n "${ATP_STORAGE_BUCKET:-}" ]]
 }
 
+read_atp_storage_credential() {
+    local var_name="$1"
+    local file_name="$2"
+    local file_path="${INTEGRATION_TESTS_SECRETS_DIR}/${file_name}"
+
+    if [[ -f "$file_path" && -r "$file_path" ]]; then
+        local val
+        val="$(tr -d '\n\r' <"$file_path")"
+        if [[ -n "$val" ]]; then
+            export "$var_name"="$val"
+        fi
+    fi
+}
+
+load_atp_storage_credentials() {
+    if [[ -z "${INTEGRATION_TESTS_SECRETS_DIR:-}" ]]; then
+        return 0
+    fi
+
+    echo "Loading ATP credentials from ${INTEGRATION_TESTS_SECRETS_DIR} (files override env when non-empty)"
+    ls -la "${INTEGRATION_TESTS_SECRETS_DIR}" 2>&1 || echo "WARN: cannot list ${INTEGRATION_TESTS_SECRETS_DIR}"
+
+    read_atp_storage_credential ATP_STORAGE_USERNAME ATP_STORAGE_USERNAME
+    read_atp_storage_credential ATP_STORAGE_PASSWORD ATP_STORAGE_PASSWORD
+}
+
 # Environment initialization module
 init_environment() {
     echo "Initializing environment..."
+
+    load_atp_storage_credentials
 
     # Compute current date and time
     if [[ -z "${CURRENT_DATE}" ]]; then


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR completes the migration of ATP S3 credentials delivery for integration tests from **`secretKeyRef` environment variables** to **Kubernetes Secret volume mounts** (file-based injection), as required by the updated secrets approach used across Qubership services (Kafka, RabbitMQ, Consul, etc.).

### Problem

After switching Helm charts to mount ATP credentials as files instead of injecting them via `secretKeyRef`, the integration-tests container failed at startup with:

```
ERROR: S3 upload is configured (ATP_STORAGE_BUCKET is set) but required variables are missing or empty: ATP_STORAGE_USERNAME ATP_STORAGE_PASSWORD
```

The S3 adapter in the base integration-tests image still expected credentials only in environment variables, while the chart no longer populated `ATP_STORAGE_USERNAME` / `ATP_STORAGE_PASSWORD` in `env`.

### Solution

**Helm chart (`consul-service`)**

- When `integrationTests.atpReport.enabled` is true:
  - Set `INTEGRATION_TESTS_SECRETS_DIR=/mnt/secrets/env`
  - Mount `*-atp-storage-secret` as a volume with items:
    - `atp-storage-username` → `ATP_STORAGE_USERNAME`
    - `atp-storage-password` → `ATP_STORAGE_PASSWORD`
  - Remove `secretKeyRef` for ATP credentials (file-based delivery only)
- Credentials still originate from `integrationTests.atpReport.atpStorage.username/password` in Helm values (populated via CI secrets / `--set-string`); the Kubernetes Secret is unchanged, only the delivery mechanism to the pod changed.

**Integration-tests image**

- Use base image with ATP file-based credential support (`qubership-docker-integration-tests` with updated `scripts/adapter-S3/init.sh`).
- `init.sh` loads credentials from `{INTEGRATION_TESTS_SECRETS_DIR}/ATP_STORAGE_*` when the directory is set.
- **Backward compatibility:** if `INTEGRATION_TESTS_SECRETS_DIR` is unset, credentials continue to be read from environment variables (legacy `secretKeyRef` / docker-compose flow). Non-empty mounted files override env when both are present.

**CI / test-pipelines (fork, separate PR if applicable)**

- Pass ATP S3 credentials from GitHub Secrets via `helm_deploy` (`--set-string`).
- Align `atpReport.atpStorage` paths and fork image registry/tag for branch builds.

### Verified behavior

Consul nightly (allure) run on `feat/atp-integration` confirmed:

- Mount present: `ATP_STORAGE_USERNAME` (20 bytes), `ATP_STORAGE_PASSWORD` (40 bytes) under `/mnt/secrets/env`
- Log: `Loading ATP credentials from /mnt/secrets/env (files override env when non-empty)`
- Log: `ATP report upload to S3 enabled` / `SUCCESS: Environment initialized successfully`
- S3 sync upload to `s3://qstp-consul/...` started successfully

## Related Tickets & Documents

- Related Issue #154

**Dependency:** base image changes in `qubership-docker-integration-tests` (`init.sh`, branch `fix/atp-integration-secrets`) must be published before or together with this PR.

## QA Instructions, Screenshots, Recordings

### Prerequisites

- GitHub Secrets in the service repo (or org): `AWS_S3_ACCESS_KEY_ID`, `AWS_S3_ACCESS_KEY_SECRET`
- `integrationTests.atpReport.enabled: true` and non-empty `atpReport.atpStorage.bucket`
- Integration-tests image built from a base image that includes the updated `init.sh`

### Helm install (local / CI)

1. Deploy with ATP enabled, e.g. nightly template `consul_clean_all_on_sc_allure.yml` or:

   ```bash
   helm upgrade --install consul ./charts/helm/consul-service -n consul \
     --set integrationTests.enabled=true \
     --set integrationTests.atpReport.enabled=true \
     --set-string integrationTests.atpReport.atpStorage.username="$AWS_KEY" \
     --set-string integrationTests.atpReport.atpStorage.password="$AWS_SECRET"
   ```

2. Verify Secret and mount:

   ```bash
   kubectl get secret -n consul -l app.kubernetes.io/name=consul-integration-tests-runner
   kubectl exec -n consul deploy/consul-integration-tests-runner -- ls -la /mnt/secrets/env
   kubectl exec -n consul deploy/consul-integration-tests-runner -- wc -c /mnt/secrets/env/ATP_STORAGE_USERNAME
   ```

3. Check pod logs for:

   ```
   Loading ATP credentials from /mnt/secrets/env
   ATP report upload to S3 enabled
   SUCCESS: Environment initialized successfully
   ```

4. Confirm **no** error: `ATP_STORAGE_USERNAME ... missing or empty`.

### Backward compatibility (legacy env-only)

Deploy **without** volume mount / without `INTEGRATION_TESTS_SECRETS_DIR`, but **with** `ATP_STORAGE_USERNAME` / `ATP_STORAGE_PASSWORD` in `env` via `secretKeyRef` — startup should still succeed on the updated base image.

### CI

- Run `Run Consul Pipeline` workflow with scope **nightly**, branch `feat/atp-integration`, `wait_for_dev_build: true`.
- Job **Clean [branch] with Allure Report** should pass ATP init and upload reports to S3.

### Breaking Change checklist

_If your PR includes any deployment or processing changes, please utilize this checklist:_

- [x] Does it change any deployment parameters, logic of their working or rename them?
  - **Yes.** ATP credentials are no longer injected via `secretKeyRef` into `ATP_STORAGE_USERNAME` / `ATP_STORAGE_PASSWORD` env vars. Charts must mount `*-atp-storage-secret` and set `INTEGRATION_TESTS_SECRETS_DIR`. Helm value paths remain `integrationTests.atpReport.atpStorage.*`.
- [x] Did update from previous version tested with the same set of deployment parameters?
  - **Yes.** Tested via Consul nightly CI with existing allure template + GitHub Secrets; file-only path verified after removing `secretKeyRef`.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: ATP credential loading is covered by integration-tests startup validation in `init.sh` and by existing Robot/consul CI pipelines (nightly allure). No new unit tests added in this repo.
- [ ] I need help with writing tests